### PR TITLE
Make top menu sticky

### DIFF
--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Navigation() {
   return (
-    <nav className="bg-gray-800 text-white p-4 sticky top-0 z-50">
+    <nav className="bg-gray-800 text-white p-4 sticky top-0 z-50 shadow-lg border-b border-gray-700">
       <div className="container mx-auto flex justify-between items-center">
         <ul className="flex space-x-6">
           <li>


### PR DESCRIPTION
Add shadow and bottom border to the top navigation bar to visually enhance its sticky appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-6be4a6a0-f4d8-42fc-be15-6936da7ffc93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6be4a6a0-f4d8-42fc-be15-6936da7ffc93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

