### PR TITLE
Adjust build time for user timezone

### DIFF
--- a/src/app/components/BuildInfo.tsx
+++ b/src/app/components/BuildInfo.tsx
@@ -6,12 +6,16 @@ import type { BuildInfo } from '@/utils/buildInfo';
 export default function BuildInfo() {
   const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
   const [loading, setLoading] = useState(true);
+  const [localizedBuildTime, setLocalizedBuildTime] = useState<string>('');
 
   useEffect(() => {
     fetch('/api/build-info')
       .then(res => res.json())
       .then(data => {
         setBuildInfo(data);
+        // Convert ISO timestamp to user's local timezone
+        const buildTime = new Date(data.buildTime).toLocaleString();
+        setLocalizedBuildTime(buildTime);
         setLoading(false);
       })
       .catch(error => {
@@ -39,7 +43,7 @@ export default function BuildInfo() {
   return (
     <div className="text-sm text-gray-400 flex flex-col items-end">
       <div className="text-xs">
-        Built: {buildInfo.buildTime}
+        Built: {localizedBuildTime}
       </div>
       <div className="text-xs">
         Commit:{' '}

--- a/src/data/build-info.json
+++ b/src/data/build-info.json
@@ -1,6 +1,6 @@
 {
-  "buildTime": "2025-09-01T19:51:51.374Z",
-  "commitHash": "c4ff4633fca44c806c42d7e51edd8a8185125fee",
-  "commitShort": "c4ff463",
-  "githubUrl": "https://github.com/merklegroot/hudapp/commit/c4ff4633fca44c806c42d7e51edd8a8185125fee"
+  "buildTime": "2025-09-01T20:02:26.705Z",
+  "commitHash": "fa1cfe750583e0baa8e0ab1f1294c33698b0f24c",
+  "commitShort": "fa1cfe7",
+  "githubUrl": "https://github.com/merklegroot/hudapp/commit/fa1cfe750583e0baa8e0ab1f1294c33698b0f24c"
 }

--- a/src/utils/buildInfo.ts
+++ b/src/utils/buildInfo.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 export interface BuildInfo {
-  buildTime: string;
+  buildTime: string; // ISO timestamp for client-side timezone conversion
   commitHash: string;
   commitShort: string;
   githubUrl: string;
@@ -21,19 +21,15 @@ export function getBuildInfo(): BuildInfo {
   if (fs.existsSync(buildInfoPath)) {
     try {
       const buildInfoData = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
-      // Convert ISO string to localized string for display
-      const buildTime = new Date(buildInfoData.buildTime).toLocaleString();
-      return {
-        ...buildInfoData,
-        buildTime
-      };
+      // Return raw ISO timestamp for client-side timezone conversion
+      return buildInfoData;
     } catch (error) {
       console.warn('Could not read build info file:', error);
     }
   }
   
   // Fallback to runtime generation (for development)
-  const buildTime = new Date().toLocaleString();
+  const buildTime = new Date().toISOString();
   
   let commitHash = '';
   let commitShort = '';


### PR DESCRIPTION
Adjust build time in the menu to display in the user's local timezone.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6a478d6-de8f-438d-9f90-ff837ff4373d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6a478d6-de8f-438d-9f90-ff837ff4373d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

