### PR TITLE
Wrap menu on small screens

### DIFF
--- a/src/app/components/Navigation.tsx
+++ b/src/app/components/Navigation.tsx
@@ -4,8 +4,8 @@ import BuildInfo from "./BuildInfo";
 export default function Navigation() {
   return (
     <nav className="bg-gray-800 text-white p-4 sticky top-0 z-50 shadow-lg border-b border-gray-700">
-      <div className="container mx-auto flex justify-between items-center">
-        <ul className="flex space-x-6">
+      <div className="container mx-auto flex flex-col lg:flex-row lg:justify-between lg:items-center gap-4">
+        <ul className="flex flex-wrap gap-4 lg:gap-6">
           <li>
             <Link href="/" className="hover:text-gray-300 transition-colors">
               Machine


### PR DESCRIPTION
Make the navigation menu wrap on small screens.

The previous `flex space-x-6` layout prevented menu items from wrapping, causing overflow on smaller viewports. This change introduces `flex-wrap` and responsive `flex-col`/`flex-row` layouts with `gap` spacing to ensure the menu items stack and wrap gracefully on small screens while maintaining the horizontal layout on larger screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dc6a015-5ea2-4e20-8df4-f1195b50b814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dc6a015-5ea2-4e20-8df4-f1195b50b814">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

